### PR TITLE
Dio interceptors

### DIFF
--- a/lib/src/core/services/exceptions/server/server_error_mapper.dart
+++ b/lib/src/core/services/exceptions/server/server_error_mapper.dart
@@ -1,22 +1,40 @@
+import 'dart:convert';
 import 'package:dio/dio.dart';
-
-import 'server_exceptions.dart';
+import 'package:where_to_go_today/src/core/services/exceptions/server/server_exceptions.dart';
 
 /// Сущность, которая преобразует ошибки сервера в ошибки приложенния
 /// для дальнейшей обработки.
 class ServerErrorMapper {
   /// Для обработки остальных серверных ошибок
   /// необходимо задать новые целочисленные константы, соотвтетсвующие кодам.
+  static const int _badRequest = 400;
+  static const int _unauthorized = 401;
   static const int _notFound = 404;
 
   static Exception fromDioError(DioError error) {
     final statusCode = error.response?.statusCode!;
-    
+
     /// Для обработки остальных серверных ошибок
     /// нужно написать дополнительные блоки в условном выражении,
     /// предварительно создав классы исключений.
-    if (statusCode == _notFound) {
-      return NotFoundException();
+    switch (statusCode) {
+      case _notFound:
+        return NotFoundException();
+      case _unauthorized:
+        return UnauthorizedException();
+      case _badRequest:
+        if (error.response != null) {
+          final code = json.decode(error.response.toString())['code'] as int;
+
+          switch (code) {
+            case 101:
+              return ImageSoLargeException();
+            default:
+              break;
+          }
+        }
+
+        break;
     }
 
     /// Возвращается по-умолчанию для остальных ошибок

--- a/lib/src/core/services/network/dio/dio_error_interceptor.dart
+++ b/lib/src/core/services/network/dio/dio_error_interceptor.dart
@@ -1,0 +1,22 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:where_to_go_today/src/core/services/exceptions/server/server_error_mapper.dart';
+import 'package:where_to_go_today/src/core/services/exceptions/server/server_exceptions.dart';
+
+class DioErrorInterceptor extends Interceptor {
+  @override
+  void onError(DioError err, ErrorInterceptorHandler handler) {
+    final exception = ServerErrorMapper.fromDioError(err);
+    if (exception is NotFoundException) {
+      throw exception;
+    } else if (exception is UnauthorizedException) {
+      //TODO(Sanlovty): необходимость попытки перезапросить токен, и вывести сообщение в консоль.
+      debugPrint('Необходимо перезапросить токен');
+      throw exception;
+    } else if (exception is ImageSoLargeException) {
+      throw exception;
+    } else {
+      handler.next(err);
+    }
+  }
+}

--- a/lib/src/core/services/network/dio/dio_module.dart
+++ b/lib/src/core/services/network/dio/dio_module.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:where_to_go_today/src/core/services/network/dio/dio_error_interceptor.dart';
 import 'package:where_to_go_today/src/core/services/urls.dart';
 
 /// Класс-модуль для конфигурации dio
@@ -10,6 +11,7 @@ class DioModule {
     ..interceptors.addAll(
       [
         LogInterceptor(),
+        DioErrorInterceptor(),
       ],
     );
 }

--- a/test/api/server_error_mapper_test.dart
+++ b/test/api/server_error_mapper_test.dart
@@ -35,7 +35,7 @@ void main() {
       );
 
       test(
-        'Если пришла 400, провести парсинг тела. Если код внутри == 101, вернуть ImageIsSoLargeException',
+        'Если пришла 400, провести парсинг тела. Если код внутри == 101, вернуть ImageSoLargeException',
         () {
           final error = _makeDioError(
             400,


### PR DESCRIPTION
# Ссылка на задачу
Задача #4 

# Что было сделано

- Добавлены новые statusCode'ы _(400,401)_ , а так же switch, который в зависимости от код по разному обрабатывает коды в [ServerErrorMapper](https://github.com/boostgrade/wtgt_delta/blob/7e169ae74dcafe8afcb24f386763b83be53b7a50/lib/src/core/services/exceptions/server/server_error_mapper.dart).  

 > Так, например, ```case 401:``` решает поставленную в условиях задачу с парсингом внутрилежащего кода, проверкой его на равенство ```101``` и бросанием ошибки ```ImageSoLargeException```

- Создан интерцептор [DioErrorInterceptor](https://github.com/boostgrade/wtgt_delta/blob/7e169ae74dcafe8afcb24f386763b83be53b7a50/lib/src/core/services/network/dio/dio_error_interceptor.dart) для обработки приходящих через метод ```void onError(..)``` ошибок ```Dio``` при помощи [ServerErrorMapper](https://github.com/boostgrade/wtgt_delta/blob/7e169ae74dcafe8afcb24f386763b83be53b7a50/lib/src/core/services/exceptions/server/server_error_mapper.dart).

-  [DioErrorInterceptor](https://github.com/boostgrade/wtgt_delta/blob/7e169ae74dcafe8afcb24f386763b83be53b7a50/lib/src/core/services/network/dio/dio_error_interceptor.dart) добавлен в [DioModule ](https://github.com/boostgrade/wtgt_delta/blob/7e169ae74dcafe8afcb24f386763b83be53b7a50/lib/src/core/services/network/dio/dio_module.dart).

- В тестах [server_error_mapper_test.dart](https://github.com/boostgrade/wtgt_delta/blob/7e169ae74dcafe8afcb24f386763b83be53b7a50/test/api/server_error_mapper_test.dart) изменено название ошибки с ```ImageIsSoLargeException``` на ```ImageSoLargeException``` в виду неактуальности.

# Как проверить работу?

- Ознакомиться с изменёнными файлами.
- Проверить результаты [тестов](https://github.com/boostgrade/wtgt_delta/blob/7e169ae74dcafe8afcb24f386763b83be53b7a50/test/api/server_error_mapper_test.dart).

# Чек-лист

- [x] Функциональность протестирована и работает корректно

Closes #4