### PR TITLE
Добавление правила always_use_package_imports в линтер

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -22,6 +22,7 @@ linter:
     avoid_print: true # Uncomment to disable the `avoid_print` rule
     prefer_single_quotes: true # Uncomment to enable the `prefer_single_quotes` rule
     noop_primitive_operations: true
+    always_use_package_imports: true
 
 dart_code_metrics:
   metrics:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,9 @@
+import 'package:where_to_go_today/src/features/app/ui/app.dart';
 import 'package:where_to_go_today/src/features/app/ui/app_vm.dart';
 import 'package:where_to_go_today/src/di/app_dependency.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import 'src/features/app/ui/app.dart';
 
 void main() async {
   final globalDeps = AppDependencies();

--- a/lib/src/core/services/exceptions/server/server_error_mapper.dart
+++ b/lib/src/core/services/exceptions/server/server_error_mapper.dart
@@ -1,6 +1,6 @@
 import 'package:dio/dio.dart';
+import 'package:where_to_go_today/src/core/services/exceptions/server/server_exceptions.dart';
 
-import 'server_exceptions.dart';
 
 /// Сущность, которая преобразует ошибки сервера в ошибки приложенния
 /// для дальнейшей обработки.

--- a/lib/src/core/ui/base/view_model_disposer_mixin.dart
+++ b/lib/src/core/ui/base/view_model_disposer_mixin.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/widgets.dart';
-
-import 'view_model.dart';
+import 'package:where_to_go_today/src/core/ui/base/view_model.dart';
 
 /// Миксин, предоставляющий возможность отписать [ViewModel].
 /// Подставляем вьюмоедль через геттер.
-mixin ViewModelDisposerMixin<W extends StatefulWidget, VM extends ViewModel> on State<W> {
+mixin ViewModelDisposerMixin<W extends StatefulWidget, VM extends ViewModel>
+    on State<W> {
   VM get vm;
 
   @override

--- a/lib/src/core/ui/errors_handling/scenario_error_handler/scenario_error_handler.dart
+++ b/lib/src/core/ui/errors_handling/scenario_error_handler/scenario_error_handler.dart
@@ -1,4 +1,4 @@
-import '../error_handler.dart';
+import 'package:where_to_go_today/src/core/ui/errors_handling/error_handler.dart';
 
 /// Одна из реализаций [ErrorHandler]
 /// Содержит атрибут класса [ErrorScenario], который необходимо задать в конструкторе

--- a/lib/src/core/ui/errors_handling/scenario_error_handler/scenarios/snackbar_error_scenarios.dart
+++ b/lib/src/core/ui/errors_handling/scenario_error_handler/scenarios/snackbar_error_scenarios.dart
@@ -1,8 +1,7 @@
 import 'package:where_to_go_today/src/core/services/exceptions/server/server_exceptions.dart';
+import 'package:where_to_go_today/src/core/ui/errors_handling/scenario_error_handler/scenario_error_handler.dart';
 import 'package:where_to_go_today/src/core/ui/messages/message_controller.dart';
 import 'package:where_to_go_today/src/core/ui/messages/types/error_snackbar.dart';
-
-import '../scenario_error_handler.dart';
 
 /// Реализация сценария, при котором при каждой ошибке всплывает снекбар
 class SnackBarErrorScenarios implements ErrorScenario {

--- a/lib/src/core/ui/messages/default_message_controller.dart
+++ b/lib/src/core/ui/messages/default_message_controller.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'message_controller.dart';
-import 'types/message_type.dart';
+import 'package:where_to_go_today/src/core/ui/messages/message_controller.dart';
+import 'package:where_to_go_today/src/core/ui/messages/types/message_type.dart';
 
 /// Эта сущность отвечает только за показ сообщений.
 /// Для этого внутри создается ключ, который устанваливается в 

--- a/lib/src/core/ui/messages/types/snack_bar_message_type.dart
+++ b/lib/src/core/ui/messages/types/snack_bar_message_type.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:where_to_go_today/src/core/ui/messages/types/message_type.dart';
 
-import 'message_type.dart';
 
 /// Сущность отвечающая за создание снекбаров.
 /// Все уведомления-снекбары расширяют этот абстрактый тип.

--- a/lib/src/di/app_dependency.dart
+++ b/lib/src/di/app_dependency.dart
@@ -1,3 +1,4 @@
+import 'package:where_to_go_today/src/di/base/dependency_bundle.dart';
 import 'package:where_to_go_today/src/features/settings/service/event/event.dart';
 import 'package:where_to_go_today/src/features/settings/service/settings_bloc.dart';
 import 'package:where_to_go_today/src/features/settings/service/repository/settings_repository.dart';
@@ -6,7 +7,6 @@ import 'package:where_to_go_today/src/core/ui/errors_handling/scenario_error_han
 import 'package:where_to_go_today/src/core/ui/errors_handling/scenario_error_handler/scenarios/snackbar_error_scenarios.dart';
 import 'package:where_to_go_today/src/core/ui/messages/default_message_controller.dart';
 
-import 'base/dependency_bundle.dart';
 
 /// Класс с глобальными зависимостями приложения
 /// Здесь бужем описывать то, что является синглтонами.

--- a/lib/src/di/app_provider.dart
+++ b/lib/src/di/app_provider.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
-
-import 'app_dependency.dart';
+import 'package:where_to_go_today/src/di/app_dependency.dart';
 
 class AppProvider extends StatelessWidget {
   final Widget child;

--- a/lib/src/features/main/main_screen.dart
+++ b/lib/src/features/main/main_screen.dart
@@ -1,12 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-
-import 'main_screen_vm.dart';
+import 'package:where_to_go_today/src/features/main/main_screen_vm.dart';
 
 /// Глвный экран с табами
 class MainScreen extends StatelessWidget {
-
   final MainScreenVm vm;
 
   static const double _labelSize = 12.0;
@@ -39,7 +37,9 @@ class MainScreen extends StatelessWidget {
             // TODO: поменять иконки из дизайна, когда они появятся
             BottomNavigationBarItem(
               icon: const Icon(Icons.search),
-              activeIcon: const Icon(Icons.search,),
+              activeIcon: const Icon(
+                Icons.search,
+              ),
               label: AppLocalizations.of(context)!.placesTabName,
             ),
             BottomNavigationBarItem(

--- a/lib/src/features/main/main_screen_route.dart
+++ b/lib/src/features/main/main_screen_route.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'main_screen_vm.dart';
-import 'main_screen.dart';
+import 'package:where_to_go_today/src/features/main/main_screen.dart';
+import 'package:where_to_go_today/src/features/main/main_screen_vm.dart';
 
 /// Рроут экрана [MainScreen]
 class MainScreenRoute extends MaterialPage {

--- a/lib/src/features/settings/service/settings_bloc.dart
+++ b/lib/src/features/settings/service/settings_bloc.dart
@@ -1,10 +1,9 @@
 import 'package:bloc/bloc.dart';
+import 'package:where_to_go_today/src/features/settings/service/event/event.dart';
+import 'package:where_to_go_today/src/features/settings/service/repository/settings_repository.dart';
 import 'package:where_to_go_today/src/features/settings/service/state/state.dart';
 import 'package:flutter/material.dart';
 import 'package:where_to_go_today/src/core/services/base/throw_exception_bloc.dart';
-
-import 'event/event.dart';
-import 'repository/settings_repository.dart';
 
 /// A class that many Widgets can interact with to read user settings, update
 /// user settings, or listen to user settings changes.
@@ -13,7 +12,6 @@ import 'repository/settings_repository.dart';
 /// uses the SettingsService to store and retrieve user settings.
 class SettingsBloc extends Bloc<SettingsEvent, SettingsState>
     with CanThrowExceptionBlocMixin {
-
   // Make SettingsService a private variable so it is not used directly.
   final SettingsRepository _settingsService;
 
@@ -56,5 +54,4 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState>
   Future<void> _loadSettings() async {
     _themeMode = await _settingsService.themeMode();
   }
-
 }


### PR DESCRIPTION
# Ссылка на задачу
Задача #6

# Что было сделано
- Добавлено правило в линтер
- Все relative import'ы заменены на package style

# Как проверить работу?

- Просмотреть изменения коммита
- Проверить через dart/flutter analyze

# Чек-лист

- [x] Функциональность протестирована и работает корректно

Closes #6